### PR TITLE
Use board size constant in attack detection

### DIFF
--- a/src/main/java/GaT/Minimax.java
+++ b/src/main/java/GaT/Minimax.java
@@ -441,7 +441,7 @@ public class Minimax {
     private static boolean isPositionUnderAttack(GameState state, int pos, boolean byRed) {
         long attackers = byRed ? (state.redTowers | state.redGuard) : (state.blueTowers | state.blueGuard);
 
-        for (int i = 0; i < 64; i++) {
+        for (int i = 0; i < GameState.NUM_SQUARES; i++) {
             if ((attackers & GameState.bit(i)) != 0) {
                 int height = byRed ? state.redStackHeights[i] : state.blueStackHeights[i];
                 if (height == 0 && (byRed ? state.redGuard : state.blueGuard) != GameState.bit(i)) continue;


### PR DESCRIPTION
## Summary
- replace hardcoded loop bound with `GameState.NUM_SQUARES`
- this avoids assuming a 64-square board

## Testing
- `mvn test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.6)*

------
https://chatgpt.com/codex/tasks/task_e_6871757a838883318ec270385258cfbb