### PR TITLE
Fix FEN parser handling for multi-digit tower heights

### DIFF
--- a/src/main/java/GaT/Objects/GameState.java
+++ b/src/main/java/GaT/Objects/GameState.java
@@ -311,9 +311,12 @@ public class GameState {
 
                 // Empty squares
                 if (Character.isDigit(ch)) {
-                    int count = ch - '0';
+                    int start = i;
+                    while (i < row.length() && Character.isDigit(row.charAt(i))) {
+                        i++;
+                    }
+                    int count = Integer.parseInt(row.substring(start, i));
                     file += count;
-                    i++;
                     continue;
                 }
 
@@ -321,14 +324,16 @@ public class GameState {
 
                 if (ch == 'r' || ch == 'b') {
                     boolean isBlue = ch == 'b';
-                    i++;
+                    int start = i + 1;
+                    while (start < row.length() && Character.isDigit(row.charAt(start))) {
+                        start++;
+                    }
 
                     int height = 1;
-                    // Look ahead for ONE digit only (0–7)
-                    if (i < row.length() && Character.isDigit(row.charAt(i))) {
-                        height = row.charAt(i) - '0';
-                        i++;
+                    if (start > i + 1) {
+                        height = Integer.parseInt(row.substring(i + 1, start));
                     }
+                    i = start;
 
                     if (isBlue) {
                         state.blueTowers |= bit(index);


### PR DESCRIPTION
## Summary
- improve `GameState.fromFen` so tower heights with multiple digits are parsed correctly

## Testing
- `mvn -q -DskipTests=false test` *(fails: Could not transfer artifact due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6871732848108331822635bbfb1d0e76